### PR TITLE
added unit length of inches to table header

### DIFF
--- a/veggies.csv
+++ b/veggies.csv
@@ -1,4 +1,4 @@
-Vegetable, Length, Color
+Vegetable, Length (inches), Color
 Potatooo,6, White
 Corn,4, Yellow
 Pineapple,9, Yellow


### PR DESCRIPTION
Hey Dhrumil, 


The table didn't have any unit lengths (it just said potato was 6, but 6 what???) - it should have been in inches. So I fixed it. Please review and add back to main branch. 

Thanks,

Dhrumil