### PR TITLE
Change the hyperlink for info on purple carrots

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,7 +27,7 @@
 
 	<p> Now let's talk about gym socks. Gym socks are very smelly. So smelly in fact that they make your feet smell bad. actually, I think that it is the other way around. Feet actually imbue the smell into the socks; the socks are not actually the soure of the smell. Did you know that? Go figure! </p>
 
-	<p> Now carrots, those are orange. Did you know that <a href="http://www.todayifoundout.com/index.php/2010/04/carrots-used-to-be-purple-before-the-17th-century/">carrots actually used to be purple? </a> Yeah, I didn't know that either. But after I read the article I just linked to, I learned it. Then, I knew it! What an interesting fact. I didn't personally unearth that fact, but I linked to it from another website. I also don't unearth carrots; I buy them at the grocery store. </p>
+	<p> Now carrots, those are orange. Did you know that <a href="https://www.zmescience.com/feature-post/health/food-and-nutrition/purple-carrots-21032011/">carrots actually used to be purple? </a> Yeah, I didn't know that either. But after I read the article I just linked to, I learned it. Then, I knew it! What an interesting fact. I didn't personally unearth that fact, but I linked to it from another website. I also don't unearth carrots; I buy them at the grocery store. </p>
 
 	<!-- Insert picture of a purple carrot below this line -->
 


### PR DESCRIPTION
I have changed the hyperlink of "carrots actually used to be purple", and it nows refers to a new website - (https://www.zmescience.com/feature-post/health/food-and-nutrition/purple-carrots-21032011/)