### PR TITLE
Extra useless text was removed from the carrot paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,9 +27,9 @@
 
 	<p> Now let's talk about gym socks. Gym socks are very smelly. So smelly in fact that they make your feet smell bad. actually, I think that it is the other way around. Feet actually imbue the smell into the socks; the socks are not actually the soure of the smell. Did you know that? Go figure! </p>
 
-	<p> Now carrots, those are orange. Did you know that <a href="http://www.todayifoundout.com/index.php/2010/04/carrots-used-to-be-purple-before-the-17th-century/">carrots actually used to be purple? </a> Yeah, I didn't know that either. But after I read the article I just linked to, I learned it. Then, I knew it! What an interesting fact. I didn't personally unearth that fact, but I linked to it from another website. I also don't unearth carrots; I buy them at the grocery store. </p>
-
-	<!-- Insert picture of a purple carrot below this line -->
+	<p> Now carrots, those are orange. Did you know that <a href="http://www.todayifoundout.com/index.php/2010/04/carrots-used-to-be-purple-before-the-17th-century/">carrots actually used to be purple? </a> 
+		
+		<!-- Insert picture of a purple carrot below this line -->
 
 	<p> In conclusion, gym socks aren't vegetables, carrots used to be purple and you now know the average length of a potato. But you don't know not the distribution of potato lengths or how the length differs by potato type. I hope you can now identify whether or not what you're eating is a vegetable.</p>
 


### PR DESCRIPTION
I just removed the extra text from the carrot paragraph because it did not make any sense and did not add any informational value.

Therefore, I suggest to incorporate my edits in the main branch.

Cheers,
Andy